### PR TITLE
Refine predicate filtering

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/common/BasicAnswerSet.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/BasicAnswerSet.java
@@ -2,12 +2,14 @@ package at.ac.tuwien.kr.alpha.common;
 
 import java.util.*;
 
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 
 /**
  * Copyright (c) 2016, the Alpha Team.
  */
 public class BasicAnswerSet implements AnswerSet {
+	public static final BasicAnswerSet EMPTY = new BasicAnswerSet(emptySet(), emptyMap());
+
 	private final Set<Predicate> predicates;
 	private final Map<Predicate, Set<PredicateInstance>> predicateInstances;
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -124,6 +124,10 @@ public class NaiveGrounder extends AbstractGrounder {
 		Map<Predicate, Set<PredicateInstance>> predicateInstances = new HashMap<>();
 		HashSet<Predicate> knownPredicates = new HashSet<>();
 
+		if (!trueAtoms.iterator().hasNext()) {
+			return BasicAnswerSet.EMPTY;
+		}
+
 		// Iterate over all true atomIds, computeNextAnswerSet instances from atomStore and add them if not filtered.
 		for (int trueAtom : trueAtoms) {
 			PredicateInstance predicateInstance = atomStore.getPredicateInstance(new AtomId(trueAtom));
@@ -137,10 +141,12 @@ public class NaiveGrounder extends AbstractGrounder {
 			Set<PredicateInstance> instances = predicateInstances.get(predicateInstance.predicate);
 			instances.add(predicateInstance);
 		}
-		Set<Predicate> predicateList = new HashSet<>();
-		predicateList.addAll(knownPredicates);
 
-		return new BasicAnswerSet(predicateList, predicateInstances);
+		if (knownPredicates.isEmpty()) {
+			return null;
+		}
+
+		return new BasicAnswerSet(knownPredicates, predicateInstances);
 	}
 
 	/**

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ParsedTreeVisitor.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ParsedTreeVisitor.java
@@ -54,10 +54,13 @@ public class ParsedTreeVisitor extends ASPCore2BaseVisitor<CommonParsedObject> {
 		if (ctx.query() != null) {
 			notSupportedSyntax(ctx.query());
 		}
+
+		final ParsedProgram program = new ParsedProgram();
+
 		if (ctx.statements() == null) {
-			throw new RuntimeException("Input program is empty.");
+			return program;
 		}
-		ParsedProgram program = new ParsedProgram();
+
 		for (CommonParsedObject parsedObject :
 			((ListOfParsedObjects)visitStatements(ctx.statements())).objects) {
 			if (parsedObject instanceof ParsedFact) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -30,6 +30,7 @@ public class DefaultSolver extends AbstractSolver {
 	private final Assignment assignment;
 
 	private int decisionLevel;
+	private boolean initialize = true;
 
 	private boolean didChange;
 
@@ -44,8 +45,9 @@ public class DefaultSolver extends AbstractSolver {
 	@Override
 	protected boolean tryAdvance(Consumer<? super AnswerSet> action) {
 		// Get basic rules and facts from grounder
-		if (store.isEmpty()) {
+		if (initialize) {
 			obtainNoGoodsFromGrounder();
+			initialize = false;
 		} else {
 			// We already found one Answer-Set and are requested to find another one
 			doBacktrack();
@@ -75,6 +77,11 @@ public class DefaultSolver extends AbstractSolver {
 				doChoice(nextChoice);
 			} else if (assignment.getMBTCount() == 0) {
 				AnswerSet as = translate(assignment.getTrueAssignments());
+
+				if (as == null) {
+					return true;
+				}
+
 				LOGGER.debug("Answer-Set found: {}", as);
 				LOGGER.trace("Choices: {}", choiceStack);
 				action.accept(as);

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/NaiveSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/NaiveSolver.java
@@ -82,6 +82,11 @@ public class NaiveSolver extends AbstractSolver {
 				doChoice();
 			} else if (noMBTValuesReamining()) {
 				AnswerSet as = getAnswerSetFromAssignment();
+
+				if (as == null) {
+					return true;
+				}
+
 				LOGGER.debug("Answer-Set found: {}", as);
 				LOGGER.trace("Choice stack: {}", choiceStack);
 				action.accept(as);


### PR DESCRIPTION
~~This is a proposal to resolve #3.~~ (Turns out this does not resolve the other issue, however might still be interesting and I will continue working here.)

I assume that predicates like `ChoiceOn` and `ChoiceOff` do not carry any meaning from the perspective of the author of the input program (they are merely "tools" for the sake of grounding and communicating choice points between grounder and solver). Therefore they should not be output in "final" answer sets anyway. Obviously, I used the filtering facility we already had in mind when designing `AbstractSolver` to filter said predicates :sparkles:  This change is not a new global default, but rather presented by means of a new unit test.

Furthermore, I changed the semantics of `Grounder.assignmentToAnswerSet` insofar, as it should return `null` in case the set of predicates that have instances is empty. This is the more substantial change I am proposing, as it interferes with the corner case of the empty program: The empty program contains no predicates, but yields the empty answer set. Therefore, filtering needs an exception to make sure that if there are no predicates in the first place, `assignmentToAnswerSet` should not yield `null` but the empty answer set.

Along the way I fixed `NaiveGrounder` so that it now happily accepts the empty program.
