### PR TITLE
Make directory paths consistent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ gradle build
 will automatically fetch all dependencies (declared in [`build.gradle`](build.gradle)) and compile the project.
 
 Artifacts generated will be placed in `build/`. Most notably you'll find files ready for distribution at
-`build/distributions`. They contain archives which in turn contain a `bin/` directory with scripts to run Alpha on Linux
+`build/distributions/`. They contain archives which in turn contain a `bin/` directory with scripts to run Alpha on Linux
 and Windows.
 
 If you want to generate a JAR file to be run standalone, execute


### PR DESCRIPTION
all directory paths end with slashes, except that one.