### PR TITLE
Initial version of BerkMin-like heuristics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,10 +3,10 @@
 # appear in this repo by chance.
 # See list of predefined hunk headers at
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html#_defining_a_custom_hunk_header
-*.java diff=java
-*.html diff=html
-*.tex  diff=tex
-*.py   diff=python
+*.java text diff=java
+*.html text diff=html
+*.tex  text diff=tex
+*.py   text diff=python
 
 # Binary files to be handled by Git LFS
 *.jpg  filter=lfs diff=lfs merge=lfs binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-# Created by https://www.gitignore.io/api/java,gradle,intellij
+
+# Created by https://www.gitignore.io/api/java,gradle,intellij,eclipse
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
@@ -7,11 +8,9 @@
 # User-specific stuff:
 .idea/workspace.xml
 .idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
 
 # Sensitive or high-churn files:
+.idea/dataSources/
 .idea/dataSources.ids
 .idea/dataSources.xml
 .idea/dataSources.local.xml
@@ -51,6 +50,62 @@ fabric.properties
 
 # *.iml
 # modules.xml
+# .idea/misc.xml 
+# *.ipr
+
+
+### Eclipse ###
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
 
 
 ### Java ###
@@ -70,7 +125,7 @@ hs_err_pid*
 
 ### Gradle ###
 .gradle
-build/
+/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -83,6 +138,3 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
-
-# Log files
-*.log

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,5 +11,8 @@
 
 # Please keep the list sorted.
 
+# Execute the following command to see all changes made by Siemens AG: $ git log -p --author=@siemens.com
+
 Antonius Weinzierl <antonius.weinzierl@gmail.com>
 Lorenz Leutgeb <lorenz.leutgeb@gmail.com> <lorenz.leutgeb@student.tuwien.ac.at> <e1127842@student.tuwien.ac.at>
+Siemens AG

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,5 +15,9 @@
 
 # Please keep the list sorted.
 
+# Execute the following command to see all changes made by Siemens AG: $ git log -p --author=@siemens.com
+
 Antonius Weinzierl <antonius.weinzierl@gmail.com>
+Gottfried Schenner <gottfried.schenner@siemens.com>
 Lorenz Leutgeb <lorenz.leutgeb@gmail.com> <lorenz.leutgeb@student.tuwien.ac.at> <e1127842@student.tuwien.ac.at>
+Richard Taupe <richard.taupe@siemens.com>

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/NoGood.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/NoGood.java
@@ -1,9 +1,37 @@
+/**
+ * Copyright (c) 2016, the Alpha Team.
+ * All rights reserved.
+ * 
+ * Additional changes made by Siemens.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.common;
 
 import at.ac.tuwien.kr.alpha.grounder.Grounder;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.stream.IntStream;
 
 import static at.ac.tuwien.kr.alpha.common.Literals.atomOf;
 import static java.lang.Math.abs;
@@ -94,6 +122,10 @@ public class NoGood implements Iterable<Integer>, Comparable<NoGood> {
 				return literals[i++];
 			}
 		};
+	}
+	
+	public IntStream stream() {
+		return Arrays.stream(literals);
 	}
 
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/Assignment.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/Assignment.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2016, the Alpha Team.
+ * All rights reserved.
+ * 
+ * Additional changes made by Siemens.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.NoGood;
@@ -50,6 +77,10 @@ public interface Assignment extends Iterable<Assignment.Entry> {
 
 	boolean guess(int atom, ThriceTruth value);
 
+	default boolean guess(int atom, boolean value) {
+		return guess(atom, ThriceTruth.valueOf(value));
+	}
+
 	/**
 	 * Returns all atomIds that are assigned TRUE in the current assignment.
 	 * @return a list of all true assigned atoms.
@@ -90,6 +121,35 @@ public interface Assignment extends Iterable<Assignment.Entry> {
 
 	default boolean contains(NoGood noGood, int index) {
 		return contains(noGood.getLiteral(index));
+	}
+
+	/**
+	 * Determines if the given {@code noGood} is violated in the current assignment.
+	 * @param noGood
+	 * @return {@code true} iff all literals in {@code noGood} evaluate to true in the current assignment.
+	 */
+	default boolean isViolated(NoGood noGood) {
+		for (Integer literal : noGood) {
+			if (!contains(literal)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Determines if the given {@code noGood} is undefined in the current assignment.
+	 * 
+	 * @param noGood
+	 * @return {@code true} iff at least one literal in {@code noGood} is unassigned.
+	 */
+	default boolean isUndefined(NoGood noGood) {
+		for (Integer literal : noGood) {
+			if (!isAssigned(atomOf(literal))) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	Iterator<OrdinaryAssignment> ordinaryIterator();

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/ChoiceStack.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/ChoiceStack.java
@@ -1,19 +1,55 @@
+/**
+ * Copyright (c) 2016, the Alpha Team.
+ * All rights reserved.
+ * 
+ * Additional changes made by Siemens.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.AtomTranslator;
 
 import java.util.Stack;
 
+/**
+ * The stack of choices. For each choice in the current path we remember the chosen atom,
+ * the chosen value, and if the other value has been tried before (if we "backtracked" already).
+ *
+ */
 class ChoiceStack {
 	private final AtomTranslator translator;
-	private final Stack<Pair> delegate = new Stack<>();
+	private final Stack<Entry> delegate = new Stack<>();
 
 	ChoiceStack(AtomTranslator translator) {
 		this.translator = translator;
 	}
 
 	public void push(int atom, boolean value) {
-		delegate.push(new Pair(atom, value));
+		delegate.push(new Entry(atom, value, false));
+	}
+
+	public void pushBacktrack(int atom, boolean value) {
+		delegate.push(new Entry(atom, value, true));
 	}
 
 	public void remove() {
@@ -27,6 +63,10 @@ class ChoiceStack {
 	public boolean peekValue() {
 		return delegate.peek().value;
 	}
+	
+	public boolean peekBacktracked() {
+		return delegate.peek().backtracked;
+	}
 
 	@Override
 	public String toString() {
@@ -37,13 +77,15 @@ class ChoiceStack {
 		return delegate.size();
 	}
 
-	private class Pair {
+	private class Entry {
 		int atom;
 		boolean value;
+		boolean backtracked;
 
-		public Pair(int atom, boolean value) {
+		public Entry(int atom, boolean value, boolean backtracked) {
 			this.atom = atom;
 			this.value = value;
+			this.backtracked = backtracked;
 		}
 
 		@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/NaiveSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/NaiveSolver.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2016, the Alpha Team.
+ * All rights reserved.
+ * 
+ * Additional changes made by Siemens.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
@@ -256,7 +283,7 @@ public class NaiveSolver extends AbstractSolver {
 		if (lastGuessedTruthValue) {
 			// Guess false now
 			truthAssignments.put(lastGuessedAtom, false);
-			choiceStack.push(lastGuessedAtom, false);
+			choiceStack.pushBacktrack(lastGuessedAtom, false);
 			newTruthAssignments.add(lastGuessedAtom);
 			decisionLevels.get(decisionLevel).add(lastGuessedAtom);
 			didChange = true;

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/BerkMin.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/BerkMin.java
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) 2016 Siemens AG
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package at.ac.tuwien.kr.alpha.solver.heuristics;
+
+import static at.ac.tuwien.kr.alpha.common.Literals.atomOf;
+import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.FALSE;
+import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.TRUE;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Random;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import at.ac.tuwien.kr.alpha.common.Literals;
+import at.ac.tuwien.kr.alpha.common.NoGood;
+import at.ac.tuwien.kr.alpha.solver.Assignment;
+import at.ac.tuwien.kr.alpha.solver.ThriceTruth;
+
+/**
+ * The BerkMin heuristic, as described in (but adapted for lazy grounding):
+ * Goldberg, E.; Novikov, Y. (2002): BerkMin: A fast and robust SAT-solver.
+ * In : Design, Automation and Test in Europe Conference and Exhibition, 2002. Proceedings. IEEE, pp. 142–149.
+ * 
+ * Copyright (c) 2016 Siemens AG
+ */
+public class BerkMin implements BranchingHeuristic {
+	
+	public static final double DEFAULT_ACTIVITY = 0.0;
+	public static final int DEFAULT_CHOICE_ATOM = 0;
+
+	private Assignment assignment;
+	private Map<Integer, Double> activityCounters = new HashMap<>();
+	private Map<Integer, Integer> signCounters = new HashMap<>();
+	private Deque<NoGood> stackOfNoGoods = new ArrayDeque<NoGood>();
+	private int decayAge = 10;
+	private double decayFactor = 0.25;
+	private int stepsSinceLastDecay;
+	private Random rand = new Random();
+	private Predicate<? super Integer> isAtomActiveChoicePoint;
+
+	public BerkMin(Assignment assignment, Predicate<? super Integer> isAtomActiveChoicePoint) {
+		this.assignment = assignment;
+		this.isAtomActiveChoicePoint = isAtomActiveChoicePoint;
+	}
+
+	public BerkMin(Assignment assignment, Predicate<? super Integer> isAtomActiveChoicePoint, int decayAge, double decayFactor) {
+		this(assignment, isAtomActiveChoicePoint);
+		this.decayAge = decayAge;
+		this.decayFactor = decayFactor;
+	}
+
+	/**
+	 * Gets the number of steps after which all counters are decayed (i.e. multiplied by {@link #getDecayFactor()}.
+	 */
+	public int getDecayAge() {
+		return decayAge;
+	}
+
+	/**
+	 * Sets the number of steps after which all counters are decayed (i.e. multiplied by {@link #getDecayFactor()}.
+	 */
+	public void setDecayAge(int decayAge) {
+		this.decayAge = decayAge;
+	}
+
+	/**
+	 * Gets the factor by which all counters are multiplied to decay after {@link #getDecayAge()}.
+	 */
+	public double getDecayFactor() {
+		return decayFactor;
+	}
+
+	/**
+	 * Sets the factor by which all counters are multiplied to decay after {@link #getDecayAge()}.
+	 */
+	public void setDecayFactor(double decayFactor) {
+		this.decayFactor = decayFactor;
+	}
+
+	@Override
+	public void violatedNoGood(NoGood violatedNoGood) {
+		pushToStack(violatedNoGood);
+		for (Integer literal : violatedNoGood) {
+			incrementActivityCounter(literal);
+			// TODO: actually we should not count the conflict nogood itself, but nogoods responsible for
+			// the conflict!
+			incrementSignCounter(literal);
+		}
+		decayAllIfTimeHasCome();
+	}
+
+	@Override
+	public void newNoGood(NoGood newNoGood) {
+		pushToStack(newNoGood);
+		for (Integer literal : newNoGood) {
+			incrementSignCounter(literal);
+		}
+	}
+
+	@Override
+	public void newNoGoods(Collection<NoGood> newNoGoods) {
+		for (NoGood noGood : newNoGoods) {
+			newNoGood(noGood);
+		}
+	}
+
+	@Override
+	public double getActivity(int literal) {
+		Double activity = activityCounters.get(atomOf(literal));
+		return defaultActivityIfNull(activity);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * In BerkMin, the atom to choose on is the most active atom in the current top clause.
+	 * Here, we can only consider atoms which are currently active choice points. If we do not find such an atom in the current top clause, we consider the next
+	 * undefined nogood in the stack, then the one after that and so on.
+	 */
+	@Override
+	public int chooseAtom() {
+		for (NoGood noGood : stackOfNoGoods) {
+			if (assignment.isUndefined(noGood)) {
+				int mostActiveAtom = getMostActiveChoosableAtom(noGood);
+				if (mostActiveAtom != DEFAULT_CHOICE_ATOM) {
+					return mostActiveAtom;
+				}
+			}
+		}
+		return DEFAULT_CHOICE_ATOM;
+	}
+	
+	@Override
+	public boolean chooseSign(int atom) {
+		if (atom <= 0) {
+			throw new IllegalArgumentException("Atom must be a positive integer.");
+		}
+		
+		if (assignment.getTruth(atom) == ThriceTruth.MBT) {
+			return true;
+		}
+		
+		int positiveCounter = signCounters.getOrDefault(atom, 0);
+		int negativeCounter = signCounters.getOrDefault(-atom, 0);
+		if (positiveCounter > negativeCounter) {
+			return false;
+		} else if (negativeCounter > positiveCounter) {
+			return true;
+		} else {
+			return rand.nextBoolean();
+		}
+	}
+
+	private void pushToStack(NoGood violatedNoGood) {
+		// TODO: stackOfNoGoods should not only contain violated nogoods, but ALL nogoods!
+		// TODO: ... or not. In Wasp, it seems that the stack contains only learned nogoods, while the polarity counters know of all "rules" (nogoods).
+		stackOfNoGoods.push(violatedNoGood);
+	}
+
+	private void incrementActivityCounter(int literal) {
+		int atom = atomOf(literal);
+		Double currentValue = defaultActivityIfNull(activityCounters.get(atom));
+		activityCounters.put(atom, ++currentValue);
+	}
+
+	private double defaultActivityIfNull(Double activity) {
+		return activity == null ? DEFAULT_ACTIVITY : activity;
+	}
+	
+	private void incrementSignCounter(Integer literal) {
+		Integer currentValue = signCounters.getOrDefault(literal, 0);
+		signCounters.put(literal, ++currentValue);
+	}
+
+	private void decayAllIfTimeHasCome() {
+		stepsSinceLastDecay++;
+		if (stepsSinceLastDecay >= decayAge) {
+			decayAll();
+			stepsSinceLastDecay = 0;
+		}
+	}
+
+	private void decayAll() {
+		for (Entry<Integer, Double> entry : activityCounters.entrySet()) {
+			activityCounters.put(entry.getKey(), entry.getValue() * decayFactor);
+		}
+	}
+	
+	/**
+	 * Gets the most recent conflict that is still violated.
+	 * @return the violated nogood closest to the top of the stack of nogoods.
+	 */
+	NoGood getCurrentTopClause() {
+		for (NoGood noGood : stackOfNoGoods) {
+			if (assignment.isUndefined(noGood)) {
+				return noGood;
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * If {@code noGood != null}, returns the most active unassigned literal from {@code noGood}. Else, returns the most active atom of all the known atoms.
+	 * @param noGood
+	 * @return
+	 */
+	private int getMostActiveChoosableAtom(NoGood noGood) {
+		if (noGood != null) {
+			return getMostActiveChoosableAtom(noGood.stream().boxed());
+		} else {
+			return getMostActiveChoosableAtom(activityCounters.keySet().stream());
+		}
+	}
+	
+	private int getMostActiveChoosableAtom(Stream<Integer> streamOfLiterals) {
+		ActivityComparator activityComparator = new ActivityComparator();
+		Optional<Integer> mostActiveAtom = streamOfLiterals.map(Literals::atomOf).filter(this::isUnassigned).filter(isAtomActiveChoicePoint)
+				.max(activityComparator);
+		return mostActiveAtom.orElse(DEFAULT_CHOICE_ATOM);
+	}
+
+	private boolean isUnassigned(int atom) {
+		ThriceTruth truth = assignment.getTruth(atom);
+		return truth != FALSE && truth != TRUE; // do not use assignment.isAssigned(atom) because we may also choose MBTs
+	}
+
+	private class ActivityComparator implements Comparator<Integer> {
+
+		@Override
+		public int compare(Integer literal1, Integer literal2) {
+			return Double.compare(getActivity(literal1), getActivity(literal2));
+		}
+		
+	}
+
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/BranchingHeuristic.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/BranchingHeuristic.java
@@ -1,8 +1,6 @@
 /**
- * Copyright (c) 2016, the Alpha Team.
+ * Copyright (c) 2016 Siemens AG
  * All rights reserved.
- * 
- * Additional changes made by Siemens.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -25,31 +23,49 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package at.ac.tuwien.kr.alpha.solver;
+package at.ac.tuwien.kr.alpha.solver.heuristics;
 
-public enum ThriceTruth {
-	TRUE("T", true),
-	FALSE("F", false),
-	MBT("M", true);
+import at.ac.tuwien.kr.alpha.common.NoGood;
 
-	private final String asString;
-	private final boolean asBoolean;
+import java.util.Collection;
 
-	ThriceTruth(String asString, boolean asBoolean) {
-		this.asString = asString;
-		this.asBoolean = asBoolean;
-	}
+/**
+ * A heuristic that selects an atom to choose on.
+ * 
+ * Copyright (c) 2016 Siemens AG
+ *
+ */
+public interface BranchingHeuristic {
 
-	public boolean toBoolean() {
-		return asBoolean;
-	}
+	/**
+	 * Stores a newly violated {@link NoGood} and updates associated activity and sign counters.
+	 * 
+	 * @param violatedNoGood
+	 */
+	void violatedNoGood(NoGood violatedNoGood);
 
-	@Override
-	public String toString() {
-		return asString;
-	}
+	/**
+	 * Stores a newly grounded {@link NoGood} and updates associated activity counters.
+	 * 
+	 * @param newNoGood
+	 */
+	void newNoGood(NoGood newNoGood);
+	
+	/**
+	 * @see #newNoGood(NoGood)
+	 */
+	void newNoGoods(Collection<NoGood> newNoGoods);
 
-	public static ThriceTruth valueOf(boolean value) {
-		return value ? TRUE : FALSE;
-	}
+	double getActivity(int literal);
+	
+	/**
+	 * Determines an atom to choose on.
+	 */
+	int chooseAtom();
+
+	/**
+	 * Chooses a truth value for the given atom.
+	 */
+	boolean chooseSign(int atom);
+
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTest.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2016, the Alpha Team.
+ * All rights reserved.
+ * 
+ * Additional changes made by Siemens.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
@@ -136,7 +163,7 @@ public abstract class AbstractSolverTest {
 		final BasicAnswerSet.Builder base = new BasicAnswerSet.Builder()
 			.predicate("dom").instance("1").instance("2").instance("3");
 
-		List<AnswerSet> expected = Arrays.asList(
+		Set<AnswerSet> expected = new HashSet<>(Arrays.asList(
 			new BasicAnswerSet.Builder(base)
 				.predicate("q").instance("1").instance("2")
 				.predicate("p").instance("3")
@@ -167,9 +194,9 @@ public abstract class AbstractSolverTest {
 				.predicate("q").instance("3")
 				.predicate("p").instance("1").instance("2")
 				.build()
-		);
+		));
 
-		assertEquals(expected, solver.collectList());
+		assertEquals(expected, solver.collectSet());
 	}
 
 	@Test

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/BerkMinTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/BerkMinTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016 Siemens AG
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package at.ac.tuwien.kr.alpha.solver.heuristics;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import at.ac.tuwien.kr.alpha.common.NoGood;
+import at.ac.tuwien.kr.alpha.solver.BasicAssignment;
+
+/**
+ * Tests {@link BerkMin}.
+ * 
+ * Copyright (c) 2016 Siemens AG
+ *
+ */
+public class BerkMinTest {
+	
+	/**
+	 * The tolerable epsilon for double comparisons
+	 */
+	private static final double EPSILON = 0.000001;
+	
+	private BerkMin berkmin;
+	
+	@Before
+	public void setUp() {
+		this.berkmin = new BerkMin(new BasicAssignment(), a -> true);
+	}
+	
+	@Test
+	public void countPositiveLiteralsOnce() {
+		NoGood violatedNoGood = new NoGood(1, 2);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(1, berkmin.getActivity(1), EPSILON);
+		assertEquals(1, berkmin.getActivity(2), EPSILON);
+	}
+	
+	@Test
+	public void countNegativeLiteralsOnce() {
+		NoGood violatedNoGood = new NoGood(-1, -2);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(1, berkmin.getActivity(-1), EPSILON);
+		assertEquals(1, berkmin.getActivity(-2), EPSILON);
+	}
+	
+	@Test
+	public void countPositiveLiteralsTwice() {
+		NoGood violatedNoGood = new NoGood(1, 2);
+		berkmin.violatedNoGood(violatedNoGood);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(2, berkmin.getActivity(1), EPSILON);
+		assertEquals(2, berkmin.getActivity(2), EPSILON);
+	}
+	
+	@Test
+	public void countNegativeLiteralsTwice() {
+		NoGood violatedNoGood = new NoGood(-1, -2);
+		berkmin.violatedNoGood(violatedNoGood);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(2, berkmin.getActivity(-1), EPSILON);
+		assertEquals(2, berkmin.getActivity(-2), EPSILON);
+	}
+	
+	@Test
+	public void countMixedLiteralsTwice() {
+		NoGood violatedNoGood = new NoGood(1, -2);
+		berkmin.violatedNoGood(violatedNoGood);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(2, berkmin.getActivity(1), EPSILON);
+		assertEquals(2, berkmin.getActivity(-2), EPSILON);
+	}
+	
+	@Test
+	public void countPositiveLiteralsThenNegativeLiterals() {
+		berkmin.violatedNoGood(new NoGood(1, 2));
+		berkmin.violatedNoGood(new NoGood(-1, -2));
+		assertEquals(2, berkmin.getActivity(1), EPSILON);
+		assertEquals(2, berkmin.getActivity(2), EPSILON);
+	}
+	
+	@Test
+	public void reachDecayAgeOnce() {
+		berkmin.setDecayAge(3);
+		berkmin.setDecayFactor(1.0 / 3);
+		NoGood violatedNoGood = new NoGood(1, 2);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(1, berkmin.getActivity(1), EPSILON);
+		assertEquals(1, berkmin.getActivity(2), EPSILON);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(2, berkmin.getActivity(1), EPSILON);
+		assertEquals(2, berkmin.getActivity(2), EPSILON);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(1, berkmin.getActivity(1), EPSILON);
+		assertEquals(1, berkmin.getActivity(2), EPSILON);
+	}
+	
+	@Test
+	public void reachDecayAgeTwice() {
+		berkmin.setDecayAge(2);
+		berkmin.setDecayFactor(0.75);
+		NoGood violatedNoGood = new NoGood(1, 2);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(1, berkmin.getActivity(1), EPSILON);
+		assertEquals(1, berkmin.getActivity(2), EPSILON);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(1.5, berkmin.getActivity(1), EPSILON);
+		assertEquals(1.5, berkmin.getActivity(2), EPSILON);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(2.5, berkmin.getActivity(1), EPSILON);
+		assertEquals(2.5, berkmin.getActivity(2), EPSILON);
+		berkmin.violatedNoGood(violatedNoGood);
+		assertEquals(2.625, berkmin.getActivity(1), EPSILON);
+		assertEquals(2.625, berkmin.getActivity(2), EPSILON);
+	}
+	
+}


### PR DESCRIPTION
To implement a berkmin-like heuristics for a lazy-grounding ASP solver, an interface BranchingHeuristic has been created which is implemented by BerkMin.
The following changes to DefaultSolver have been made:

- When a NoGood is violated, it is reported to the branching heuristic.
- When a new NoGood is obtained from the grounder, it is reported to the branching heuristic.
- When a choice has to be made, the branching heuristic is employed to choose atom and sign (polarity).
- Because the sign chosen first is not always true anymore, a backtrack does not always choose false anymore but goes into the branch that has not yet been explored.
- If the branching heuristic cannot make a choice, we fall back to the old method to compute a choice.