### PR TITLE
Check for internal atoms using flag not predicate name

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/AtomStore.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/AtomStore.java
@@ -22,7 +22,7 @@ public class AtomStore {
 
 	public AtomStore() {
 		// Create atomId for falsum (currently not needed, but it gets atomId 0, which cannot represent a negated literal).
-		createAtomId(new BasicAtom(new BasicPredicate("\u22A5", 0), true, new Term[0]));
+		createAtomId(new BasicAtom(new BasicPredicate("\u22A5", 0), true));
 	}
 
 	public AtomId getHighestAtomId() {

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/HexBridge.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/HexBridge.java
@@ -20,16 +20,12 @@ public class HexBridge implements Bridge {
 			int id = it.nextIndex();
 			BasicAtom basicAtom = it.next();
 
-			if (id == 0 || !assignment.contains(id)) {
+			if (!assignment.contains(id) || basicAtom.isInternal()) {
 				continue;
 			}
 
-			if (basicAtom.predicate.getPredicateName() != "_R_" &&
-				basicAtom.predicate.getPredicateName() != "ChoiceOn" &&
-				basicAtom.predicate.getPredicateName() != "ChoiceOff") {
-				List<String> l = assignment.get(id).getTruth().toBoolean() ? trueAtoms : falseAtoms;
-				l.add(basicAtom.toString().replace(" ", "").replace("()", ""));
-			}
+			List<String> l = assignment.get(id).getTruth().toBoolean() ? trueAtoms : falseAtoms;
+			l.add(basicAtom.toString().replace(" ", "").replace("()", ""));
 		}
 
 		String[][] externalNogoods = externalAtomsQuery(trueAtoms.toArray(new String[trueAtoms.size()]), falseAtoms.toArray(new String[falseAtoms.size()]));

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/HexBridge.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/HexBridge.java
@@ -20,7 +20,7 @@ public class HexBridge implements Bridge {
 			int id = it.nextIndex();
 			BasicAtom basicAtom = it.next();
 
-			if (!assignment.contains(id) || basicAtom.isInternal()) {
+			if (basicAtom.isInternal() || !assignment.contains(id)) {
 				continue;
 			}
 


### PR DESCRIPTION
Predicate names can be arbitrarily chosen by the grounder, use the `internal` flag instead.

If I did not mess up, this should work and be more portable (independent of grounder implementation).