### PR TITLE
Alphahex rule import

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/BridgedGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/BridgedGrounder.java
@@ -22,11 +22,21 @@ public abstract class BridgedGrounder extends AbstractGrounder {
 		this.bridges = bridges;
 	}
 
-	protected Set<NoGood> collectExternal(ReadableAssignment assignment, AtomStore atomStore) {
+	protected Set<NoGood> collectExternalNogoods(ReadableAssignment assignment, AtomStore atomStore) {
 		Set<NoGood> collectedNoGoods = new HashSet<>();
 
 		for (Bridge bridge : bridges) {
 			collectedNoGoods.addAll(bridge.getNoGoods(assignment, atomStore));
+		}
+
+		return collectedNoGoods;
+	}
+
+	protected Set<NonGroundRule> collectExternalRules(ReadableAssignment assignment, AtomStore atomStore, IntIdGenerator intIdGenerator) {
+		Set<NonGroundRule> collectedNoGoods = new HashSet<>();
+
+		for (Bridge bridge : bridges) {
+			collectedNoGoods.addAll(bridge.getRules(assignment, atomStore, intIdGenerator));
 		}
 
 		return collectedNoGoods;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/BridgedGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/BridgedGrounder.java
@@ -5,8 +5,10 @@ import at.ac.tuwien.kr.alpha.common.NoGood;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.grounder.bridges.Bridge;
 import at.ac.tuwien.kr.alpha.grounder.parser.ParsedProgram;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public abstract class BridgedGrounder extends AbstractGrounder {
@@ -22,21 +24,11 @@ public abstract class BridgedGrounder extends AbstractGrounder {
 		this.bridges = bridges;
 	}
 
-	protected Set<NoGood> collectExternalNogoods(ReadableAssignment assignment, AtomStore atomStore) {
+	protected Set<NoGood> collectExternalNogoods(ReadableAssignment assignment, AtomStore atomStore, Pair<Map<Integer, Integer>, Map<Integer, Integer>> newChoiceAtoms, IntIdGenerator choiceAtomsGenerator) {
 		Set<NoGood> collectedNoGoods = new HashSet<>();
 
 		for (Bridge bridge : bridges) {
-			collectedNoGoods.addAll(bridge.getNoGoods(assignment, atomStore));
-		}
-
-		return collectedNoGoods;
-	}
-
-	protected Set<NonGroundRule> collectExternalRules(ReadableAssignment assignment, AtomStore atomStore, IntIdGenerator intIdGenerator) {
-		Set<NonGroundRule> collectedNoGoods = new HashSet<>();
-
-		for (Bridge bridge : bridges) {
-			collectedNoGoods.addAll(bridge.getRules(assignment, atomStore, intIdGenerator));
+			collectedNoGoods.addAll(bridge.getNoGoods(assignment, atomStore, newChoiceAtoms, choiceAtomsGenerator));
 		}
 
 		return collectedNoGoods;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -263,8 +263,17 @@ public class NaiveGrounder extends BridgedGrounder {
 			modifiedWorkingMemory.markRecentlyAddedInstancesDone();
 		}
 
-		for (NoGood noGood : collectExternal(assignment, atomStore)) {
+		// Import additional noGoods from external sources
+		for (NoGood noGood : collectExternalNogoods(assignment, atomStore)) {
 			registerIfNeeded(noGood, newNoGoods);
+		}
+
+		// Import additional ground rules from external sources and generate corresponding noGoods
+		for (NonGroundRule rule : collectExternalRules(assignment, atomStore, intIdGenerator)) {
+			List<NoGood> noGoods = generateNoGoodsFromGroundSubstitution(rule, new VariableSubstitution());
+			for (NoGood noGood : noGoods) {
+				registerIfNeeded(noGood, newNoGoods);
+			}
 		}
 
 		modifiedWorkingMemories = new HashSet<>();

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -25,10 +25,10 @@ public class NaiveGrounder extends BridgedGrounder {
 	 * Atoms corresponding to rule bodies use this predicate, first term is rule number,
 	 * second is a term containing variable substitutions.
 	 */
-	private static final BasicPredicate RULE_BODIES_PREDICATE = new BasicPredicate("_R_", 2);
+	public static final BasicPredicate RULE_BODIES_PREDICATE = new BasicPredicate("_R_", 2);
 
-	private static final BasicPredicate CHOICE_ON_PREDICATE = new BasicPredicate("ChoiceOn", 1);
-	private static final BasicPredicate CHOICE_OFF_PREDICATE = new BasicPredicate("ChoiceOff", 1);
+	public static final BasicPredicate CHOICE_ON_PREDICATE = new BasicPredicate("ChoiceOn", 1);
+	public static final BasicPredicate CHOICE_OFF_PREDICATE = new BasicPredicate("ChoiceOff", 1);
 
 	private final IntIdGenerator intIdGenerator = new IntIdGenerator();
 	private final IntIdGenerator nogoodIdGenerator = new IntIdGenerator();
@@ -264,16 +264,8 @@ public class NaiveGrounder extends BridgedGrounder {
 		}
 
 		// Import additional noGoods from external sources
-		for (NoGood noGood : collectExternalNogoods(assignment, atomStore)) {
+		for (NoGood noGood : collectExternalNogoods(assignment, atomStore, newChoiceAtoms, choiceAtomsGenerator)) {
 			registerIfNeeded(noGood, newNoGoods);
-		}
-
-		// Import additional ground rules from external sources and generate corresponding noGoods
-		for (NonGroundRule rule : collectExternalRules(assignment, atomStore, intIdGenerator)) {
-			List<NoGood> noGoods = generateNoGoodsFromGroundSubstitution(rule, new VariableSubstitution());
-			for (NoGood noGood : noGoods) {
-				registerIfNeeded(noGood, newNoGoods);
-			}
 		}
 
 		modifiedWorkingMemories = new HashSet<>();

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/Bridge.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/Bridge.java
@@ -3,9 +3,12 @@ package at.ac.tuwien.kr.alpha.grounder.bridges;
 import at.ac.tuwien.kr.alpha.common.ReadableAssignment;
 import at.ac.tuwien.kr.alpha.common.NoGood;
 import at.ac.tuwien.kr.alpha.grounder.AtomStore;
+import at.ac.tuwien.kr.alpha.grounder.IntIdGenerator;
+import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
 
 import java.util.Collection;
 
 public interface Bridge {
 	Collection<NoGood> getNoGoods(ReadableAssignment assignment, AtomStore atomStore);
+	Collection<NonGroundRule> getRules(ReadableAssignment assignment, AtomStore atomStore, IntIdGenerator intIdGenerator);
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/Bridge.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/Bridge.java
@@ -5,10 +5,11 @@ import at.ac.tuwien.kr.alpha.common.NoGood;
 import at.ac.tuwien.kr.alpha.grounder.AtomStore;
 import at.ac.tuwien.kr.alpha.grounder.IntIdGenerator;
 import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collection;
+import java.util.Map;
 
 public interface Bridge {
-	Collection<NoGood> getNoGoods(ReadableAssignment assignment, AtomStore atomStore);
-	Collection<NonGroundRule> getRules(ReadableAssignment assignment, AtomStore atomStore, IntIdGenerator intIdGenerator);
+	Collection<NoGood> getNoGoods(ReadableAssignment assignment, AtomStore atomStore, Pair<Map<Integer, Integer>, Map<Integer, Integer>> newChoiceAtoms, IntIdGenerator choiceAtomsGenerator);
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/HexBridge.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/HexBridge.java
@@ -2,20 +2,112 @@ package at.ac.tuwien.kr.alpha.grounder.bridges;
 
 import at.ac.tuwien.kr.alpha.common.*;
 import at.ac.tuwien.kr.alpha.grounder.AtomStore;
+import at.ac.tuwien.kr.alpha.grounder.IntIdGenerator;
+import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
 
 import java.util.*;
 
 public class HexBridge implements Bridge {
+	private List<Integer> processedNoGoods = new ArrayList<>();
+
 	public static native void sendResults(String[][] resultsArray);
 	private static native String[][] externalAtomsQuery(String[] trueAtoms, String[] falseAtoms);
 
 	public Collection<NoGood> getNoGoods(ReadableAssignment assignment, AtomStore atomStore) {
-		Set<NoGood> nogoods = new HashSet<>();
+		Set<NoGood> noGoods = new HashSet<>();
+/*
+		List<String[]> externalNogoods = getExternalNoGoods(assignment, atomStore);
 
+		for (String[] externalNogood : externalNogoods) {
+
+			int[] externalNgLiterals = new int[externalNogood.length];
+
+			externalNogood[0] = externalNogood[0].replace("aux_n_", "-aux_r_");
+
+			for (int k = 0; k < externalNogood.length; k++) {
+				boolean isNegative = false;
+
+				if (externalNogood[k].charAt(0) == '-') {
+					isNegative = true;
+					externalNogood[k] = externalNogood[k].substring(1, externalNogood[k].length());
+				}
+
+				BasicAtom atom = atomFromLiteral(externalNogood[k]);
+
+				int atomId = atomStore.add(atom);
+
+				if (isNegative) {
+					externalNgLiterals[k] = -atomId;
+				} else {
+					externalNgLiterals[k] = atomId;
+				}
+			}
+
+			noGoods.add(new NoGood(externalNgLiterals, 0));
+		}*/
+		return noGoods;
+	}
+
+	public Collection<NonGroundRule> getRules(ReadableAssignment assignment, AtomStore atomStore, IntIdGenerator intIdGenerator) {
+		Set<NonGroundRule> rules = new HashSet<>();
+
+		List<String[]> externalNogoods = getExternalNoGoods(assignment, atomStore);
+
+		for (String[] externalNogood : externalNogoods) {
+
+			List<Atom> pos = new ArrayList<>();
+			List<Atom> neg = new ArrayList<>();
+			Atom head = null;
+
+			externalNogood[0] = externalNogood[0].replace("aux_n_", "-aux_r_");
+
+			for (int k = 0; k < externalNogood.length; k++) {
+				boolean isNegative = false;
+
+				if (externalNogood[k].charAt(0) == '-') {
+					isNegative = true;
+					externalNogood[k] = externalNogood[k].substring(1, externalNogood[k].length());
+				}
+
+				BasicAtom atom = atomFromLiteral(externalNogood[k]);
+
+				if (isNegative) {
+					if (k == 0) {
+						head = atom;
+					} else {
+						neg.add(atom);
+					}
+				} else {
+					pos.add(atom);
+				}
+			}
+
+			rules.add(new NonGroundRule(
+				intIdGenerator.getNextId(),
+				pos,
+				neg,
+				head
+			));
+		}
+		return rules;
+	}
+
+	private BasicAtom atomFromLiteral(String literal) {
+		String[] lit = literal.split("\\(|,|\\)");
+		Term[] terms = new Term[lit.length - 1];
+
+		for (int j = 1; j < lit.length; j++) {
+			terms[j - 1] = ConstantTerm.getInstance(lit[j]);
+		}
+
+		return new BasicAtom(new BasicPredicate(lit[0], lit.length - 1), false, terms);
+	}
+
+	private List<String[]> getExternalNoGoods(ReadableAssignment assignment, AtomStore atomStore) {
 		List<String> trueAtoms = new ArrayList<>();
 		List<String> falseAtoms = new ArrayList<>();
 
-		for (ListIterator<BasicAtom> it = atomStore.listIterator(); it.hasNext();) {
+		for (ListIterator<BasicAtom> it = atomStore.listIterator(); it.hasNext(); ) {
 			int id = it.nextIndex();
 			BasicAtom basicAtom = it.next();
 
@@ -27,41 +119,26 @@ public class HexBridge implements Bridge {
 			l.add(basicAtom.toString().replace(" ", "").replace("()", ""));
 		}
 
-		String[][] externalNogoods = externalAtomsQuery(trueAtoms.toArray(new String[trueAtoms.size()]), falseAtoms.toArray(new String[falseAtoms.size()]));
+		String[][] externalNgs = externalAtomsQuery(trueAtoms.toArray(new String[trueAtoms.size()]), falseAtoms.toArray(new String[falseAtoms.size()]));
+		List<String[]> externalNoGoods = new ArrayList<>();
 
-		for (int i = 0; i < externalNogoods.length; i++) {
-
-			int[] externalNgLiterals = new int[externalNogoods[i].length];
-
-			for (int k = 0; k < externalNogoods[i].length; k++) {
-				externalNogoods[i][k] = externalNogoods[i][k].replace("aux_n_", "-aux_r_");
-
-				boolean isNegative = false;
-
-				if (externalNogoods[i][k].charAt(0) == '-') {
-					isNegative = true;
-					externalNogoods[i][k] = externalNogoods[i][k].substring(1, externalNogoods[i][k].length());
-				}
-
-				String[] literal = externalNogoods[i][k].split("\\(|,|\\)");
-				Term[] terms = new Term[literal.length - 1];
-
-				for (int j = 1; j < literal.length; j++) {
-					terms[j - 1] = ConstantTerm.getInstance(literal[j]);
-				}
-
-				BasicAtom atom = new BasicAtom(new BasicPredicate(literal[0], literal.length - 1), false, terms);
-				int atomId = atomStore.add(atom);
-
-				if (isNegative) {
-					externalNgLiterals[k] = -atomId;
-				} else {
-					externalNgLiterals[k] = atomId;
-				}
+		for (int i = 0; i < externalNgs.length; i++) {
+			if (!processedNoGoods.contains(noGoodHashCode(externalNgs[i]))) {
+				processedNoGoods.add(noGoodHashCode(externalNgs[i]));
+				externalNoGoods.add(externalNgs[i]);
 			}
-
-			nogoods.add(new NoGood(externalNgLiterals, 0));
 		}
-		return nogoods;
+
+		return externalNoGoods;
+	}
+
+	private int noGoodHashCode(String[] rule) {
+		String ruleString = "";
+
+		for (int i = 0; i < rule.length; i++) {
+			ruleString += rule[i];
+		}
+
+		return ruleString.hashCode();
 	}
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/HexBridge.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/bridges/HexBridge.java
@@ -154,7 +154,7 @@ public class HexBridge implements Bridge {
 			int id = it.nextIndex();
 			BasicAtom basicAtom = it.next();
 
-			if (basicAtom.isInternal() || !assignment.contains(id)) {
+			if (basicAtom.isInternal() || !assignment.isAssigned(id)) {
 				continue;
 			}
 
@@ -174,6 +174,6 @@ public class HexBridge implements Bridge {
 			string += strings[i];
 		}
 
-		return (Integer.toString(string.hashCode()));
+		return string;
 	}
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -190,8 +190,16 @@ public class DefaultSolver extends AbstractSolver {
 	}
 
 	private void assignUnassignedToFalse() {
+		boolean isFirst = true;
 		for (Integer atom : unassignedAtoms) {
-			assignment.assign(atom, FALSE, null);
+			decisionCounter++;
+			if (isFirst) {
+				assignment.guess(atom, FALSE);
+				choiceStack.pushBacktrack(atom, false);
+				isFirst = false;
+			} else {
+				assignment.assign(atom, FALSE);
+			}
 		}
 	}
 


### PR DESCRIPTION
I've adapted the `HexBridge` such that the nogoods imported from Hex are not added directly anymore, but are transformed into nogoods representing the corresponding rules in Alpha. First, I had added a second method to the `Bridge` interface for importing new ground rules. Now, the transformation is made directly inside `getNoGoods`, so that only minimal changes are required in the other classes. Only `RULE_BODIES_PREDICATE` in `NaiveGrounder` has to be _public_ and additional arguments need to be passed to `getNoGoods` for generating new choice atoms. So, I think the new version is better; the the previous one is contained in 111d9f5.