### PR TITLE
Removing unused method

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/Util.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Util.java
@@ -59,18 +59,6 @@ public class Util {
 		}
 	}
 
-	/**
-	 * Constructs a {@link Set} containing only the given element.
-	 * 
-	 * @param element
-	 * @return
-	 */
-	public static <E> Set<E> set(E element) {
-		Set<E> set = new HashSet<E>(1);
-		set.add(element);
-		return set;
-	}
-
 	public static <T extends Comparable<T>> int compareSortedSets(SortedSet<T> a, SortedSet<T> b) {
 		if (a.size() != b.size()) {
 			return a.size() - b.size();


### PR DESCRIPTION
Removing unused util method (only usage was removed in 3e591db9c121d7ebd38055c92af4f43aaa79c50d because the same result can be achieved by Collections.singleton).