### PR TITLE
Accept multiple input files

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/CustomErrorListener.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/CustomErrorListener.java
@@ -4,12 +4,21 @@ import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 
-public class SwallowingErrorListener extends BaseErrorListener {
+public class CustomErrorListener extends BaseErrorListener {
 	RecognitionException recognitionException;
+
+	private final String fileName;
+
+	public CustomErrorListener(String fileName) {
+		this.fileName = fileName;
+	}
 
 	@Override
 	public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
 		super.syntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
+
+		System.err.println(fileName + ":" + line + ":" + charPositionInLine + ": " + msg);
+
 		this.recognitionException = e;
 	}
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -167,7 +167,22 @@ public class Main {
 
 		ParsedProgram program = null;
 		try {
-			program = parseVisit(new FileInputStream(commandLine.getOptionValue(OPT_INPUT)));
+			InputStream input;
+
+			String[] inputFileNames = commandLine.getOptionValues(OPT_INPUT);
+
+			if (inputFileNames.length == 1) {
+				input = new FileInputStream(inputFileNames[0]);
+			} else {
+				List<InputStream> inputFileStreams = new ArrayList<>(inputFileNames.length);
+				for (String inputFileName : inputFileNames) {
+					inputFileStreams.add(new FileInputStream(inputFileName));
+				}
+
+				input = new SequenceInputStream(Collections.enumeration(inputFileStreams));
+			}
+
+			program = parseVisit(input);
 		} catch (RecognitionException e) {
 			bailOut("Error while parsing input ASP program, see errors above.", e);
 		} catch (FileNotFoundException e) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -167,22 +167,13 @@ public class Main {
 
 		ParsedProgram program = null;
 		try {
-			InputStream input;
-
+			// Parse all input files and accumulate their results in one ParsedProgram.
 			String[] inputFileNames = commandLine.getOptionValues(OPT_INPUT);
+			program = parseVisit(new FileInputStream(inputFileNames[0]));
 
-			if (inputFileNames.length == 1) {
-				input = new FileInputStream(inputFileNames[0]);
-			} else {
-				List<InputStream> inputFileStreams = new ArrayList<>(inputFileNames.length);
-				for (String inputFileName : inputFileNames) {
-					inputFileStreams.add(new FileInputStream(inputFileName));
-				}
-
-				input = new SequenceInputStream(Collections.enumeration(inputFileStreams));
+			for (int i = 1; i < inputFileNames.length; i++) {
+				program.accumulate(parseVisit(new FileInputStream(inputFileNames[i])));
 			}
-
-			program = parseVisit(input);
 		} catch (RecognitionException e) {
 			bailOut("Error while parsing input ASP program, see errors above.", e);
 		} catch (FileNotFoundException e) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -175,6 +175,9 @@ public class Main {
 				program.accumulate(parseVisit(new ANTLRFileStream(inputFileNames[i])));
 			}
 		} catch (RecognitionException e) {
+			// In case a recognitionexception occured, parseVisit will
+			// already have printed an error message, so we just exit
+			// at this point without further logging.
 			System.exit(1);
 		} catch (FileNotFoundException e) {
 			bailOut(e.getMessage());

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ParsedProgram.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ParsedProgram.java
@@ -37,4 +37,10 @@ public class ParsedProgram extends CommonParsedObject {
 	public boolean addConstraint(ParsedConstraint constraint) {
 		return constraints.add(constraint);
 	}
+
+	public void accumulate(ParsedProgram program) {
+		rules.addAll(program.rules);
+		facts.addAll(program.facts);
+		constraints.addAll(program.constraints);
+	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/MainTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/MainTest.java
@@ -21,37 +21,37 @@ public class MainTest {
 	@Test
 	@Ignore
 	public void parseSimpleProgram() throws IOException {
-		parseVisit(stream(
+		parseVisit(
 			"p(X) :- q(X).\n" +
 			"q(a).\n" +
 			"q(b).\n"
-		));
+		);
 	}
 
 	@Test
 	public void parseProgramWithNegativeBody() throws IOException {
-		parseVisit(stream(
+		parseVisit(
 			"p(X) :- q(X), not q(a).\n" +
 				"q(a).\n"
-		));
+		);
 	}
 
 	@Test(expected = UnsupportedOperationException.class)
 	@Ignore
 	public void parseProgramWithFunction() throws IOException {
-		parseVisit(stream(
+		parseVisit(
 			"p(X) :- q(f(X)).\n" +
 				"q(a).\n"
-		));
+		);
 	}
 
 	@Test(expected = UnsupportedOperationException.class)
 	@Ignore
 	public void parseProgramWithDisjunctionInHead() throws IOException {
-		parseVisit(stream(
+		parseVisit(
 			"r(X) | q(X) :- q(X).\n" +
 				"q(a).\n"
-		));
+		);
 	}
 
 	@Test

--- a/src/test/java/at/ac/tuwien/kr/alpha/antlr/ParserTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/antlr/ParserTest.java
@@ -6,9 +6,7 @@ import at.ac.tuwien.kr.alpha.grounder.parser.ParsedProgram;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 import static at.ac.tuwien.kr.alpha.Main.parseVisit;
 import static org.junit.Assert.assertEquals;
@@ -17,13 +15,9 @@ import static org.junit.Assert.assertEquals;
  * Copyright (c) 2016, the Alpha Team.
  */
 public class ParserTest {
-	public static InputStream stream(String file) {
-		return new ByteArrayInputStream(file.getBytes());
-	}
-
 	@Test
 	public void parseFact() throws IOException {
-		ParsedProgram parsedProgram = parseVisit(stream("p(a,b)."));
+		ParsedProgram parsedProgram = parseVisit("p(a,b).");
 
 		assertEquals("Program contains one fact.", 1, parsedProgram.facts.size());
 		assertEquals("Predicate name of fact is p.", "p", parsedProgram.facts.get(0).getFact().predicate);
@@ -34,7 +28,7 @@ public class ParserTest {
 
 	@Test
 	public void parseFactWithFunctionTerms() throws IOException {
-		ParsedProgram parsedProgram = parseVisit(stream("p(f(a),g(h(Y)))."));
+		ParsedProgram parsedProgram = parseVisit("p(f(a),g(h(Y))).");
 
 		assertEquals("Program contains one fact.", 1, parsedProgram.facts.size());
 		assertEquals("Predicate name of fact is p.", "p", parsedProgram.facts.get(0).getFact().predicate);
@@ -45,8 +39,8 @@ public class ParserTest {
 
 	@Test
 	public void parseSmallProgram() throws IOException {
-		ParsedProgram parsedProgram = parseVisit(stream("a :- b, not d.\n" +
-			"c(X) :- p(X,a,_), q(Xaa,xaa). :- f(Y)."));
+		ParsedProgram parsedProgram = parseVisit("a :- b, not d.\n" +
+			"c(X) :- p(X,a,_), q(Xaa,xaa). :- f(Y).");
 
 		assertEquals("Program contains two rules.", 2, parsedProgram.rules.size());
 		assertEquals("Program contains one constraint.", 1, parsedProgram.constraints.size());
@@ -54,12 +48,12 @@ public class ParserTest {
 
 	@Test(expected = RecognitionException.class)
 	public void parseBadSyntax() throws IOException {
-		parseVisit(stream("Wrong Syntax."));
+		parseVisit("Wrong Syntax.");
 	}
 
 	@Test
 	public void parseBuiltinAtom() throws IOException {
-		ParsedProgram parsedProgram = parseVisit(stream("a :- p(X), X != Y, q(Y)."));
+		ParsedProgram parsedProgram = parseVisit("a :- p(X), X != Y, q(Y).");
 		assertEquals(1, parsedProgram.rules.size());
 		assertEquals(3, parsedProgram.rules.get(0).body.size());
 	}

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/PigeonHoleTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/PigeonHoleTest.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.util.Set;
 
 import static at.ac.tuwien.kr.alpha.Main.parseVisit;
-import static at.ac.tuwien.kr.alpha.MainTest.stream;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -109,7 +108,7 @@ public class PigeonHoleTest extends AbstractSolverTests {
 		addPigeons(testProgram, pigeons);
 		addHoles(testProgram, holes);
 
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram.toString()));
+		ParsedProgram parsedProgram = parseVisit(testProgram.toString());
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/SolverTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/SolverTests.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.util.*;
 
 import static at.ac.tuwien.kr.alpha.Main.parseVisit;
-import static at.ac.tuwien.kr.alpha.MainTest.stream;
 import static org.junit.Assert.assertEquals;
 
 public class SolverTests extends AbstractSolverTests {
@@ -63,7 +62,7 @@ public class SolverTests extends AbstractSolverTests {
 	@Test
 	public void testFactsOnlyProgram() throws IOException {
 		String testProgram = "p(a). p(b). foo(13). foo(16). q(a). q(c).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		Grounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -83,7 +82,7 @@ public class SolverTests extends AbstractSolverTests {
 	@Test
 	public void testSimpleRule() throws Exception {
 		String testProgram = "p(a). p(b). r(X) :- p(X).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		Grounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -104,7 +103,7 @@ public class SolverTests extends AbstractSolverTests {
 			"p(1)." +
 				"p(2)." +
 				"q(X) :-  p(X), p(1).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		Grounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -122,7 +121,7 @@ public class SolverTests extends AbstractSolverTests {
 	@Test
 	public void testProgramZeroArityPredicates() throws Exception {
 		String testProgram = "a. p(X) :- b, r(X).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		Grounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -139,7 +138,7 @@ public class SolverTests extends AbstractSolverTests {
 
 	@Test
 	public void testGuessingGroundProgram() throws Exception {
-		Solver solver = getInstance(new NaiveGrounder(parseVisit(stream("a :- not b. b :- not a."))));
+		Solver solver = getInstance(new NaiveGrounder(parseVisit("a :- not b. b :- not a.")));
 
 		Set<AnswerSet> expected = new HashSet<>(Arrays.asList(
 			new BasicAnswerSet.Builder().predicate("a").build(),
@@ -154,7 +153,7 @@ public class SolverTests extends AbstractSolverTests {
 		String testProgram = "dom(1). dom(2). dom(3)." +
 			"p(X) :- dom(X), not q(X)." +
 			"q(X) :- dom(X), not p(X).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -213,7 +212,7 @@ public class SolverTests extends AbstractSolverTests {
 			"b :- not a, not c." +
 			"c :- not a, not b.";
 
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 
 		Solver solver = getInstance(grounder);
@@ -236,7 +235,7 @@ public class SolverTests extends AbstractSolverTests {
 
 	@Test
 	public void emptyProgramYieldsEmptyAnswerSet() throws IOException {
-		ParsedProgram parsedProgram = parseVisit(stream(""));
+		ParsedProgram parsedProgram = parseVisit("");
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 
 		List<AnswerSet> answerSets = getInstance(grounder).collectList();
@@ -254,7 +253,7 @@ public class SolverTests extends AbstractSolverTests {
 			"notc :- not c.\n" +
 			":- nota,notb,notc.";
 
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 
 		Solver solver = getInstance(grounder);
@@ -306,7 +305,7 @@ public class SolverTests extends AbstractSolverTests {
 		String testProgram = "dom(1). dom(2). dom(3). dom(4). dom(5)." +
 			"p(X) :- dom(X), X = 4." +
 			"r(Y) :- dom(Y), Y <= 2.";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -335,7 +334,7 @@ public class SolverTests extends AbstractSolverTests {
 		String testProgram = "a :- 13 != 4." +
 			"b :- 2 != 3, 2 = 3." +
 			"c :- 2 <= 3, not 2 > 3.";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -364,7 +363,7 @@ public class SolverTests extends AbstractSolverTests {
 			"val(VAR,3):-var(VAR),not val(VAR,1),not val(VAR,2).\n" +
 			"%:- val(VAR1,VAL1), val(VAR2,VAL2), eq(VAL1,VAL2), not eq(VAR1,VAR2).\n" +
 			":- eq(VAL1,VAL2), not eq(VAR1,VAR2), val(VAR1,VAL1), val(VAR2,VAL2).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -435,7 +434,7 @@ public class SolverTests extends AbstractSolverTests {
 				"val(VAR,3):-var(VAR),not val(VAR,1),not val(VAR,2).\n" +
 				":- val(VAR1,VAL1), val(VAR2,VAL2), eq(VAL1,VAL2), not eq(VAR1,VAR2).\n" +
 				"%:- eq(VAL1,VAL2), not eq(VAR1,VAR2), val(VAR1,VAL1), val(VAR2,VAL2).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -497,7 +496,7 @@ public class SolverTests extends AbstractSolverTests {
 		String testProgram = "val(1,1).\n" +
 			"val(2,2).\n" +
 			"something:- val(VAR1,VAL1), val(VAR2,VAL2), anything(VAL1,VAL2).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -520,7 +519,7 @@ public class SolverTests extends AbstractSolverTests {
 			"in(X) :- not out(X), node(X).\n" +
 			"out(X) :- not in(X), node(X).\n" +
 			"pair(X,Y) :- in(X), in(Y).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -575,7 +574,7 @@ public class SolverTests extends AbstractSolverTests {
 			"in(X) :- not out(X), node(X).\n" +
 			"out(X) :- not in(X), node(X).\n" +
 			":- in(X), in(Y), edge(X,Y).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 
@@ -617,7 +616,7 @@ public class SolverTests extends AbstractSolverTests {
 	@Test
 	public void testUnsatisfiableProgram() throws IOException {
 		String testProgram = "p(a). p(b). :- p(a), p(b).";
-		ParsedProgram parsedProgram = parseVisit(stream(testProgram));
+		ParsedProgram parsedProgram = parseVisit(testProgram);
 		Grounder grounder = new NaiveGrounder(parsedProgram);
 		Solver solver = getInstance(grounder);
 


### PR DESCRIPTION
This is a quick solution to #31 

In principle it does what it needs to do. What we will need in the future is referencing the file name in case of parsing errors. Currently files are concatenated and the line numbers that ANTLR error messages refer to are probably not consistent with file numbers of actual files.

So I'd say it's a step in the right direction, but we'll need to follow up on the issue.